### PR TITLE
feat: populate docutray-advanced skill with document type configuration flow

### DIFF
--- a/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-07

--- a/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/design.md
+++ b/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The `docutray-advanced` skill is a placeholder with TODO comments. The `docutray-platform` skill (issue #5) established the pattern: SKILL.md with YAML frontmatter, progressive disclosure, `@references/` for detailed docs, under 500 lines. The advanced skill needs to follow this pattern but with a different focus — interactive agent workflow rather than API reference.
+
+The target audience is coding agents (Claude Code, Cursor, Codex) that need to guide human users through creating custom document types. This is fundamentally an interaction design problem: the skill instructs the agent on how to ask questions, in what order, and what CLI commands to run.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Teach agents the complete document type creation/update workflow via CLI
+- Provide JSON schema design guidelines optimized for LLM-based extraction
+- Document promptHints and identifyPromptHints usage
+- Keep SKILL.md under 500 lines using references for detail
+- Support progressive disclosure: don't dump all questions at once
+
+**Non-Goals:**
+- Validation rules (`dslRules`, `validationRules`) — out of scope for v1
+- Conversion spec (`conversionSpec`) and `conversionMode` details
+- SDK/REST API examples (this skill is CLI-workflow-focused, not API-reference)
+- Pipeline/steps creation (separate concern)
+
+## Decisions
+
+### Decision 1: Workflow-centric SKILL.md, not API-reference
+
+The platform skill is organized by command (convert, identify, types, steps) with multi-language examples. The advanced skill will be organized by workflow steps (check existing → create → design schema → configure hints) since the value is in the interaction pattern, not the CLI syntax.
+
+**Alternative considered:** Mirror platform's command-centric structure. Rejected because the advanced skill's core value is guiding agents through a multi-step interactive process, not documenting CLI flags.
+
+### Decision 2: Two reference files
+
+- `schema-design-reference.md` — JSON schema patterns, field types, nullable/required combos, array/object examples, enum usage. This is dense reference material that would bloat SKILL.md.
+- `document-type-workflow-reference.md` — Detailed decision tree, step-by-step flow, multi-document handling, example dialogues. Provides depth for agents that need more context.
+
+**Alternative considered:** Single reference file. Rejected because schema design and workflow flow are distinct concerns with different access patterns.
+
+### Decision 3: CLI-only examples in SKILL.md
+
+Unlike the platform skill which includes Python SDK, Node SDK, and REST API examples, this skill focuses exclusively on CLI commands. The workflow is agent-driven and CLI is the natural interface for agents executing commands on behalf of users.
+
+### Decision 4: Progressive disclosure interaction pattern
+
+The skill instructs agents to ask questions in stages:
+1. Document analysis and existing type check
+2. Name and code
+3. Main fields
+4. Additional fields and tabular data
+5. Prompt hints
+6. Schema validation with user
+7. CLI execution
+
+This prevents overwhelming users with all configuration options at once.
+
+## Risks / Trade-offs
+
+- [SKILL.md line budget] The 500-line limit requires careful editing. → Mitigation: Offload JSON schema examples and detailed workflows to references.
+- [CLI command accuracy] The `types create` and `types update` flags must match the actual CLI. → Mitigation: Reference the issue's documented CLI commands which are already implemented.
+- [Multi-agent compatibility] Different agents have different interaction capabilities. → Mitigation: Use simple ask/respond patterns that work in any agent context; avoid agent-specific features.

--- a/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/proposal.md
+++ b/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The `docutray-advanced` skill is currently a placeholder with TODO comments. Users working with documents not covered by public types need to create custom document types with extraction schemas. Coding agents have no guidance on how to lead users through this interactive process — analyzing documents, checking existing types, designing JSON schemas, configuring prompt hints, and executing the CLI commands.
+
+## What Changes
+
+- Rewrite `skills/docutray-advanced/SKILL.md` from placeholder to complete document type configuration workflow (under 500 lines)
+- Create `references/schema-design-reference.md` with detailed JSON schema patterns and field type examples
+- Create `references/document-type-workflow-reference.md` with detailed decision tree and progressive disclosure steps
+- Remove `.gitkeep` from references directory (replaced by real content)
+
+## Capabilities
+
+### New Capabilities
+- `document-type-workflow`: Interactive workflow for creating and modifying custom document types — decision tree (identify existing vs create new), progressive field discovery, multi-document handling, and CLI command execution (`types create`, `types update`, `types list`, `types get`)
+- `schema-design`: JSON schema best practices for document extraction — field types, nullable/required patterns, array/object nesting, enum usage, and LLM-friendly descriptions
+- `prompt-hints`: Usage of `promptHints` and `identifyPromptHints` for document-wide extraction instructions (date formats, decimal separators, locale conventions)
+
+### Modified Capabilities
+- `docutray-advanced-skill`: Existing skeleton spec will be extended with requirements for complete content, workflow sections, and reference files
+
+## Impact
+
+- `skills/docutray-advanced/SKILL.md` — Full rewrite from placeholder
+- `skills/docutray-advanced/references/` — Two new reference files, `.gitkeep` removed
+- No code changes, no dependencies affected — content-only change

--- a/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/specs/document-type-workflow/spec.md
+++ b/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/specs/document-type-workflow/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: SKILL.md contains document type creation workflow
+The SKILL.md SHALL include a workflow section that guides agents through creating a new document type, starting with checking existing types and ending with CLI execution.
+
+#### Scenario: Workflow starts with existing type check
+- **WHEN** an agent reads the document type creation workflow
+- **THEN** the first step SHALL instruct the agent to run `docutray types list` and `docutray identify` to check for existing types before creating a new one
+
+#### Scenario: Agent confirms create vs modify
+- **WHEN** existing types have been checked
+- **THEN** the workflow SHALL instruct the agent to confirm with the user whether they want to create a new type or modify an existing one
+
+### Requirement: Progressive field discovery
+The workflow SHALL instruct agents to gather document type fields progressively, not all at once.
+
+#### Scenario: Progressive disclosure stages
+- **WHEN** an agent follows the workflow to create a new document type
+- **THEN** it SHALL ask for information in stages: (1) name and code, (2) main fields, (3) additional fields, (4) tabular/repeating data, (5) prompt hints
+
+#### Scenario: User confirms before execution
+- **WHEN** all field information has been gathered
+- **THEN** the agent SHALL present the complete schema to the user for review before executing the CLI command
+
+### Requirement: CLI commands for type management documented
+The SKILL.md SHALL document the CLI commands for creating, updating, listing, and getting document types.
+
+#### Scenario: Create command documented
+- **WHEN** the agent needs to create a document type
+- **THEN** the skill SHALL document `docutray types create` with flags: `--name`, `--code`, `--description`, `--schema`, `--prompt-hints`, `--identify-hints`
+
+#### Scenario: Update command documented
+- **WHEN** the agent needs to modify an existing document type
+- **THEN** the skill SHALL document `docutray types update <code>` with flags: `--schema`, `--prompt-hints`, `--identify-hints`
+
+### Requirement: Multi-document-type file handling
+The SKILL.md SHALL address files that contain multiple document types (e.g., a PDF with both an invoice and a packing slip).
+
+#### Scenario: Multi-document guidance
+- **WHEN** a user describes a file containing multiple document types
+- **THEN** the workflow SHALL instruct the agent to create separate document types for each and explain how to handle them
+
+### Requirement: Detailed workflow in references
+A `references/document-type-workflow-reference.md` file SHALL contain the detailed decision tree, step-by-step flow, and example interactions.
+
+#### Scenario: Reference file exists and is cross-referenced
+- **WHEN** the SKILL.md workflow section is read
+- **THEN** it SHALL include a cross-reference to `@references/document-type-workflow-reference.md`
+
+#### Scenario: Reference contains detailed steps
+- **WHEN** the reference file is read
+- **THEN** it SHALL contain a detailed decision tree and progressive disclosure steps with example agent-user interactions

--- a/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/specs/docutray-advanced-skill/spec.md
+++ b/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/specs/docutray-advanced-skill/spec.md
@@ -1,8 +1,4 @@
-## Purpose
-
-Defines requirements for the docutray-advanced skill — document type creation, schema design, and processing pipelines.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Advanced skill skeleton exists
 The repository SHALL contain a `skills/docutray-advanced/SKILL.md` file with valid YAML frontmatter including `name` and `description` fields, populated with complete document type configuration workflow content.

--- a/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/specs/prompt-hints/spec.md
+++ b/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/specs/prompt-hints/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: promptHints usage documented
+The SKILL.md SHALL document how to use `promptHints` for document-wide extraction instructions.
+
+#### Scenario: promptHints examples
+- **WHEN** the agent reads the prompt hints section
+- **THEN** it SHALL find examples covering date formats, decimal separators, and thousand separators
+
+#### Scenario: promptHints flag in CLI
+- **WHEN** the agent needs to set prompt hints via CLI
+- **THEN** the skill SHALL document the `--prompt-hints` flag on `types create` and `types update`
+
+### Requirement: identifyPromptHints usage documented
+The SKILL.md SHALL document how to use `identifyPromptHints` to improve document type identification.
+
+#### Scenario: identifyPromptHints examples
+- **WHEN** the agent reads the identify hints section
+- **THEN** it SHALL find examples of hints that help distinguish similar document types
+
+#### Scenario: identifyPromptHints flag in CLI
+- **WHEN** the agent needs to set identify hints via CLI
+- **THEN** the skill SHALL document the `--identify-hints` flag on `types create` and `types update`

--- a/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/specs/schema-design/spec.md
+++ b/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/specs/schema-design/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: JSON schema design guidelines
+The SKILL.md SHALL include guidelines for designing JSON schemas optimized for LLM-based document extraction.
+
+#### Scenario: Required and nullable pattern
+- **WHEN** the agent designs a schema field
+- **THEN** the guidelines SHALL recommend using `"type": ["string", "null"]` with `required` to ensure fields always appear in output
+
+#### Scenario: Descriptive field descriptions
+- **WHEN** defining field descriptions
+- **THEN** the guidelines SHALL instruct agents to write descriptions that help the LLM locate and interpret values (e.g., position hints, expected format)
+
+#### Scenario: Date and enum types
+- **WHEN** defining date or fixed-value fields
+- **THEN** the guidelines SHALL recommend `format: "date"` for dates and `enum` for known fixed values
+
+#### Scenario: Tabular and repeating data
+- **WHEN** defining line items or repeating data
+- **THEN** the guidelines SHALL recommend using `array` with `items` for tabular/repeating structures
+
+### Requirement: Detailed schema reference
+A `references/schema-design-reference.md` file SHALL contain detailed JSON schema patterns, field type examples, and complex nesting patterns.
+
+#### Scenario: Reference file exists and is cross-referenced
+- **WHEN** the SKILL.md schema design section is read
+- **THEN** it SHALL include a cross-reference to `@references/schema-design-reference.md`
+
+#### Scenario: Reference covers field type combinations
+- **WHEN** the reference file is read
+- **THEN** it SHALL contain examples of string, number, date, enum, array, and object field types with nullable/required combinations

--- a/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/tasks.md
+++ b/openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/tasks.md
@@ -1,0 +1,20 @@
+## 1. SKILL.md — Core Content
+
+- [x] 1.1 Rewrite SKILL.md frontmatter and introduction (replace placeholder, keep description with trigger phrases)
+- [x] 1.2 Write "Document Type Workflow" section — decision tree: check existing types (`types list`, `identify`) → confirm create vs modify
+- [x] 1.3 Write "Creating Document Types" section — progressive interaction flow (name/code → main fields → additional fields → tabular data → prompt hints → review → execute `types create`)
+- [x] 1.4 Write "Schema Design" section — JSON schema best practices (required+nullable, descriptive descriptions, date/enum, arrays for tabular data) with cross-reference to schema-design-reference.md
+- [x] 1.5 Write "Modifying Document Types" section — `types get` to retrieve current, `types update` CLI command, workflow for changes
+- [x] 1.6 Write "Prompt Hints" section — promptHints and identifyPromptHints usage with examples (date formats, decimal separators, locale conventions)
+- [x] 1.7 Write "Multi-Document Files" section — handling files with multiple document types
+- [x] 1.8 Verify SKILL.md is under 500 lines and YAML frontmatter parses correctly
+
+## 2. Reference Files
+
+- [x] 2.1 Create `references/schema-design-reference.md` — detailed JSON schema patterns: field types (string, number, date, enum), nullable/required combinations, array/object nesting, complex examples
+- [x] 2.2 Create `references/document-type-workflow-reference.md` — detailed decision tree, step-by-step progressive disclosure flow, multi-document handling details, example agent-user interactions
+
+## 3. Cleanup
+
+- [x] 3.1 Remove `.gitkeep` from `skills/docutray-advanced/references/`
+- [x] 3.2 Verify all cross-references use `@references/filename.md` pattern

--- a/openspec/specs/document-type-workflow/spec.md
+++ b/openspec/specs/document-type-workflow/spec.md
@@ -1,0 +1,56 @@
+## Purpose
+
+Defines requirements for the document type creation and modification workflow in the docutray-advanced skill.
+
+## Requirements
+
+### Requirement: SKILL.md contains document type creation workflow
+The SKILL.md SHALL include a workflow section that guides agents through creating a new document type, starting with checking existing types and ending with CLI execution.
+
+#### Scenario: Workflow starts with existing type check
+- **WHEN** an agent reads the document type creation workflow
+- **THEN** the first step SHALL instruct the agent to run `docutray types list` and `docutray identify` to check for existing types before creating a new one
+
+#### Scenario: Agent confirms create vs modify
+- **WHEN** existing types have been checked
+- **THEN** the workflow SHALL instruct the agent to confirm with the user whether they want to create a new type or modify an existing one
+
+### Requirement: Progressive field discovery
+The workflow SHALL instruct agents to gather document type fields progressively, not all at once.
+
+#### Scenario: Progressive disclosure stages
+- **WHEN** an agent follows the workflow to create a new document type
+- **THEN** it SHALL ask for information in stages: (1) name and code, (2) main fields, (3) additional fields, (4) tabular/repeating data, (5) prompt hints
+
+#### Scenario: User confirms before execution
+- **WHEN** all field information has been gathered
+- **THEN** the agent SHALL present the complete schema to the user for review before executing the CLI command
+
+### Requirement: CLI commands for type management documented
+The SKILL.md SHALL document the CLI commands for creating, updating, listing, and getting document types.
+
+#### Scenario: Create command documented
+- **WHEN** the agent needs to create a document type
+- **THEN** the skill SHALL document `docutray types create` with flags: `--name`, `--code`, `--description`, `--schema`, `--prompt-hints`, `--identify-hints`
+
+#### Scenario: Update command documented
+- **WHEN** the agent needs to modify an existing document type
+- **THEN** the skill SHALL document `docutray types update <code>` with flags: `--schema`, `--prompt-hints`, `--identify-hints`
+
+### Requirement: Multi-document-type file handling
+The SKILL.md SHALL address files that contain multiple document types (e.g., a PDF with both an invoice and a packing slip).
+
+#### Scenario: Multi-document guidance
+- **WHEN** a user describes a file containing multiple document types
+- **THEN** the workflow SHALL instruct the agent to create separate document types for each and explain how to handle them
+
+### Requirement: Detailed workflow in references
+A `references/document-type-workflow-reference.md` file SHALL contain the detailed decision tree, step-by-step flow, and example interactions.
+
+#### Scenario: Reference file exists and is cross-referenced
+- **WHEN** the SKILL.md workflow section is read
+- **THEN** it SHALL include a cross-reference to `@references/document-type-workflow-reference.md`
+
+#### Scenario: Reference contains detailed steps
+- **WHEN** the reference file is read
+- **THEN** it SHALL contain a detailed decision tree and progressive disclosure steps with example agent-user interactions

--- a/openspec/specs/docutray-advanced-skill/spec.md
+++ b/openspec/specs/docutray-advanced-skill/spec.md
@@ -39,4 +39,4 @@ The `description` field SHALL include phrases related to advanced features to en
 
 #### Scenario: Trigger phrase coverage
 - **WHEN** the `description` field is read
-- **THEN** it MUST mention document type creation, schema design, and processing pipelines
+- **THEN** it MUST mention document type creation, schema design, and prompt hints or extraction rules

--- a/openspec/specs/prompt-hints/spec.md
+++ b/openspec/specs/prompt-hints/spec.md
@@ -1,0 +1,27 @@
+## Purpose
+
+Defines requirements for promptHints and identifyPromptHints documentation in the docutray-advanced skill.
+
+## Requirements
+
+### Requirement: promptHints usage documented
+The SKILL.md SHALL document how to use `promptHints` for document-wide extraction instructions.
+
+#### Scenario: promptHints examples
+- **WHEN** the agent reads the prompt hints section
+- **THEN** it SHALL find examples covering date formats, decimal separators, and thousand separators
+
+#### Scenario: promptHints flag in CLI
+- **WHEN** the agent needs to set prompt hints via CLI
+- **THEN** the skill SHALL document the `--prompt-hints` flag on `types create` and `types update`
+
+### Requirement: identifyPromptHints usage documented
+The SKILL.md SHALL document how to use `identifyPromptHints` to improve document type identification.
+
+#### Scenario: identifyPromptHints examples
+- **WHEN** the agent reads the identify hints section
+- **THEN** it SHALL find examples of hints that help distinguish similar document types
+
+#### Scenario: identifyPromptHints flag in CLI
+- **WHEN** the agent needs to set identify hints via CLI
+- **THEN** the skill SHALL document the `--identify-hints` flag on `types create` and `types update`

--- a/openspec/specs/schema-design/spec.md
+++ b/openspec/specs/schema-design/spec.md
@@ -1,0 +1,35 @@
+## Purpose
+
+Defines requirements for JSON schema design guidelines in the docutray-advanced skill.
+
+## Requirements
+
+### Requirement: JSON schema design guidelines
+The SKILL.md SHALL include guidelines for designing JSON schemas optimized for LLM-based document extraction.
+
+#### Scenario: Required and nullable pattern
+- **WHEN** the agent designs a schema field
+- **THEN** the guidelines SHALL recommend using `"type": ["string", "null"]` with `required` to ensure fields always appear in output
+
+#### Scenario: Descriptive field descriptions
+- **WHEN** defining field descriptions
+- **THEN** the guidelines SHALL instruct agents to write descriptions that help the LLM locate and interpret values (e.g., position hints, expected format)
+
+#### Scenario: Date and enum types
+- **WHEN** defining date or fixed-value fields
+- **THEN** the guidelines SHALL recommend `format: "date"` for dates and `enum` for known fixed values
+
+#### Scenario: Tabular and repeating data
+- **WHEN** defining line items or repeating data
+- **THEN** the guidelines SHALL recommend using `array` with `items` for tabular/repeating structures
+
+### Requirement: Detailed schema reference
+A `references/schema-design-reference.md` file SHALL contain detailed JSON schema patterns, field type examples, and complex nesting patterns.
+
+#### Scenario: Reference file exists and is cross-referenced
+- **WHEN** the SKILL.md schema design section is read
+- **THEN** it SHALL include a cross-reference to `@references/schema-design-reference.md`
+
+#### Scenario: Reference covers field type combinations
+- **WHEN** the reference file is read
+- **THEN** it SHALL contain examples of string, number, date, enum, array, and object field types with nullable/required combinations

--- a/skills/docutray-advanced/SKILL.md
+++ b/skills/docutray-advanced/SKILL.md
@@ -9,16 +9,321 @@ description: >-
 
 # DocuTray Advanced
 
-<!-- TODO: Content will be added in a separate issue -->
+Guide users through creating and managing custom document types for DocuTray. Assumes DocuTray is already set up (see `docutray-setup` skill) and the user is familiar with core commands (see `docutray-platform` skill).
 
-## Document Type Creation
+## 1. Document Type Workflow
 
-<!-- Creating and managing custom document types -->
+When a user wants to extract data from a document not covered by existing types, follow this decision tree:
 
-## Schema Design
+### Step 1: Check Existing Types
 
-<!-- Defining extraction schemas and field mappings -->
+Before creating anything, check what already exists:
 
-## Processing Pipelines
+```bash
+# Search for types matching the document
+docutray types list --search "invoice"
 
-<!-- Building and managing multi-step pipelines -->
+# Auto-detect the document type
+docutray identify document.pdf
+```
+
+### Step 2: Decide — Create or Modify
+
+Based on results:
+
+- **High-confidence match** (identify confidence >= 0.9): Use the existing type directly with `docutray convert`
+- **Partial match** (0.7–0.9 or similar type exists): Ask the user — modify the existing type or create a new one?
+- **No match** (< 0.7 or no relevant types): Proceed to create a new document type
+
+Ask the user explicitly:
+> "I found a type called `purchase_order` that's similar. Would you like to modify it for your needs, or create a new document type?"
+
+### Step 3: Route to Create or Modify
+
+- **Create new** → Follow Section 2 (Creating Document Types)
+- **Modify existing** → Follow Section 4 (Modifying Document Types)
+
+## 2. Creating Document Types
+
+Guide the user through progressive steps. **Do not ask all questions at once** — gather information incrementally.
+
+### Stage 1: Name and Code
+
+Ask the user for:
+- **Name**: Human-readable (e.g., "Purchase Order")
+- **Code**: Machine identifier, snake_case (e.g., `purchase_order`)
+- **Description**: One sentence explaining the document type
+
+### Stage 2: Main Fields
+
+Ask: "What are the main fields you need to extract from this document?"
+
+For each field, determine:
+- Field name (snake_case)
+- Type (`string`, `number`, `date`, `enum`, `boolean`)
+- Whether it's required
+- A description that helps the LLM find and interpret the value
+
+Example prompt to user:
+> "What are the 3-5 most important fields in this document? For each, tell me the name and what kind of value it holds (text, number, date, etc.)"
+
+### Stage 3: Additional Fields and Tabular Data
+
+After main fields are confirmed, ask:
+> "Are there any additional fields? Does this document have line items, rows, or other repeating data?"
+
+For tabular/repeating data, use `array` type with `items` defining the row structure.
+
+### Stage 4: Prompt Hints
+
+Ask about document-specific conventions:
+> "Are there any special formatting conventions? For example: date format (DD/MM/YYYY vs MM/DD/YYYY), number format (comma vs period for decimals), or language?"
+
+See Section 5 for prompt hints details.
+
+### Stage 5: Review and Execute
+
+Present the complete schema to the user for review before executing:
+
+```bash
+# Save schema to a file first
+cat > my_type_schema.json << 'EOF'
+{
+  "type": "object",
+  "required": ["invoice_number", "date", "total"],
+  "properties": {
+    "invoice_number": {
+      "type": ["string", "null"],
+      "description": "Unique invoice identifier, typically at top of page"
+    },
+    "date": {
+      "type": ["string", "null"],
+      "format": "date",
+      "description": "Invoice issue date"
+    },
+    "total": {
+      "type": ["number", "null"],
+      "description": "Total amount due, bottom-right of page"
+    }
+  }
+}
+EOF
+
+# Create the document type
+docutray types create \
+  --name "My Invoice" \
+  --code my_invoice \
+  --description "Custom invoice format for Acme Corp" \
+  --schema my_type_schema.json \
+  --prompt-hints "Dates are in DD/MM/YYYY format. Amounts use comma as decimal separator." \
+  --identify-hints "This is an Acme Corp invoice, identified by the logo in the top-left corner."
+```
+
+### Stage 6: Test
+
+After creation, test with a real document:
+
+```bash
+docutray convert sample-document.pdf --type my_invoice
+```
+
+Review the output with the user and iterate on the schema if needed.
+
+> **Details:** @references/document-type-workflow-reference.md — detailed decision tree, progressive disclosure steps, multi-document handling, example interactions
+
+## 3. Schema Design
+
+Design JSON schemas that help the LLM extract data accurately.
+
+### Key Principles
+
+**Use required + nullable for all fields:**
+
+```json
+{
+  "required": ["field_name"],
+  "properties": {
+    "field_name": {
+      "type": ["string", "null"]
+    }
+  }
+}
+```
+
+This ensures the field always appears in output (`required`) but accepts missing values gracefully (`null`). Prefer this over optional fields.
+
+**Write LLM-friendly descriptions:**
+
+Descriptions guide the extraction model. Include:
+- Where to find the value on the document
+- Expected format or pattern
+- Disambiguation when similar values exist
+
+```json
+{
+  "invoice_number": {
+    "type": ["string", "null"],
+    "description": "Invoice number, top-right corner, format: INV-XXXX-XXX"
+  },
+  "total_amount": {
+    "type": ["number", "null"],
+    "description": "Grand total including tax, bottom of page, after 'TOTAL DUE'"
+  }
+}
+```
+
+**Use appropriate types:**
+
+| Data | JSON Schema Type | Notes |
+|------|-----------------|-------|
+| Text | `"type": ["string", "null"]` | Default for most fields |
+| Numbers | `"type": ["number", "null"]` | Amounts, quantities, percentages |
+| Dates | `"type": ["string", "null"], "format": "date"` | Outputs ISO 8601 (YYYY-MM-DD) |
+| Fixed values | `"type": ["string", "null"], "enum": [...]` | Status, category, payment method |
+| Yes/No | `"type": ["boolean", "null"]` | Checkbox fields |
+
+**Use arrays for tabular data:**
+
+```json
+{
+  "line_items": {
+    "type": ["array", "null"],
+    "description": "Table of purchased items",
+    "items": {
+      "type": "object",
+      "properties": {
+        "description": { "type": ["string", "null"] },
+        "quantity": { "type": ["number", "null"] },
+        "unit_price": { "type": ["number", "null"] },
+        "total": { "type": ["number", "null"] }
+      }
+    }
+  }
+}
+```
+
+> **Details:** @references/schema-design-reference.md — complete field type examples, nullable/required combinations, nested objects, enum patterns, complex schema examples
+
+## 4. Modifying Document Types
+
+To modify an existing document type:
+
+### Step 1: Retrieve Current Schema
+
+```bash
+# View current type definition
+docutray types get my_invoice
+
+# Export schema to file for editing
+docutray types export my_invoice --output current_schema.json
+```
+
+### Step 2: Edit and Update
+
+Modify the exported schema file, then update:
+
+```bash
+# Update schema
+docutray types update my_invoice --schema updated_schema.json
+
+# Update prompt hints
+docutray types update my_invoice --prompt-hints "Updated: dates are now in YYYY-MM-DD format."
+
+# Update identify hints
+docutray types update my_invoice --identify-hints "Acme Corp invoice v2, new logo format."
+```
+
+### Step 3: Test Changes
+
+```bash
+docutray convert sample-document.pdf --type my_invoice
+```
+
+Compare output against the previous version to verify improvements.
+
+## 5. Prompt Hints
+
+Prompt hints provide document-wide context to the extraction model. They complement field-level descriptions with global instructions.
+
+### promptHints
+
+Used during extraction (`convert`). Tell the model about document conventions:
+
+```bash
+docutray types create ... \
+  --prompt-hints "Dates are in DD/MM/YYYY format. Amounts use period as thousand separator and comma as decimal separator (e.g., 1.234,56). All text is in Spanish."
+```
+
+**Common prompt hints:**
+
+| Hint | Example |
+|------|---------|
+| Date format | `"Dates are DD/MM/YYYY"` |
+| Decimal separator | `"Comma is decimal separator (1.234,56)"` |
+| Thousand separator | `"Period is thousand separator"` |
+| Language/locale | `"Document is in Portuguese (Brazil)"` |
+| Multi-page | `"Summary table is on the last page"` |
+| Layout | `"Two-column layout, read left column first"` |
+
+### identifyPromptHints
+
+Used during identification (`identify`). Help distinguish this type from similar documents:
+
+```bash
+docutray types create ... \
+  --identify-hints "This is an Acme Corp purchase order. Distinguished by: Acme logo top-left, PO number starting with 'PO-', and 'Purchase Order' title in header."
+```
+
+**Effective identify hints include:**
+- Visual markers (logos, headers, watermarks)
+- Unique identifiers (numbering patterns, specific labels)
+- Distinguishing features from similar document types
+
+## 6. Multi-Document Files
+
+Some files contain multiple document types (e.g., a PDF with an invoice and a packing slip).
+
+### Handling Strategy
+
+1. **Ask the user** if pages contain different document types
+2. **Create separate types** for each document type in the file
+3. **Document the relationship** in descriptions and prompt hints
+
+```bash
+# Create the primary type
+docutray types create \
+  --name "Shipping Bundle - Invoice" \
+  --code shipping_bundle_invoice \
+  --schema invoice_schema.json \
+  --prompt-hints "This is the invoice portion of a shipping bundle. Usually pages 1-2."
+
+# Create the secondary type
+docutray types create \
+  --name "Shipping Bundle - Packing Slip" \
+  --code shipping_bundle_packing_slip \
+  --schema packing_slip_schema.json \
+  --prompt-hints "This is the packing slip portion. Usually the last page."
+```
+
+For files where the same type repeats (e.g., multiple invoices in one PDF), use a single type — DocuTray handles repeated extraction automatically.
+
+> **Details:** @references/document-type-workflow-reference.md — detailed multi-document strategies and examples
+
+## 7. CLI Command Reference
+
+| Command | Description |
+|---------|-------------|
+| `docutray types list [--search <term>]` | List available document types |
+| `docutray types get <code>` | Get type details and schema |
+| `docutray types export <code> [--output <file>]` | Export schema as JSON |
+| `docutray types create --name --code --schema [--description] [--prompt-hints] [--identify-hints]` | Create new type |
+| `docutray types update <code> [--schema] [--prompt-hints] [--identify-hints]` | Update existing type |
+| `docutray identify <file>` | Auto-detect document type |
+| `docutray convert <file> --type <code>` | Convert using a type |
+
+## Scope Note
+
+This skill covers document type creation and schema design. The following are **not covered** in this version:
+- Validation rules (`dslRules`, `validationRules`)
+- Conversion spec (`conversionSpec`) and advanced `conversionMode`
+- Processing pipeline creation (see `docutray-platform` skill for running existing pipelines)

--- a/skills/docutray-advanced/SKILL.md
+++ b/skills/docutray-advanced/SKILL.md
@@ -2,9 +2,9 @@
 name: docutray-advanced
 description: >-
   Advanced DocuTray features: create custom document types, design extraction
-  schemas, and build processing pipelines. Use this skill when creating a new
+  schemas, and configure prompt hints. Use this skill when creating a new
   document type, defining schema fields, configuring extraction rules, or
-  setting up multi-step processing pipelines.
+  modifying existing document types.
 ---
 
 # DocuTray Advanced
@@ -191,6 +191,7 @@ Descriptions guide the extraction model. Include:
     "description": "Table of purchased items",
     "items": {
       "type": "object",
+      "required": ["description", "quantity", "unit_price", "total"],
       "properties": {
         "description": { "type": ["string", "null"] },
         "quantity": { "type": ["number", "null"] },

--- a/skills/docutray-advanced/references/document-type-workflow-reference.md
+++ b/skills/docutray-advanced/references/document-type-workflow-reference.md
@@ -1,0 +1,252 @@
+# Document Type Workflow — Detailed Reference
+
+## Decision Tree
+
+```
+User wants to extract data from a document
+│
+├─ Run: docutray types list --search "<keywords>"
+├─ Run: docutray identify <file>
+│
+├─ Match found (confidence >= 0.9)?
+│  ├─ YES → Use existing type: docutray convert <file> --type <code>
+│  └─ NO ↓
+│
+├─ Similar type exists (0.7–0.9 or keyword match)?
+│  ├─ YES → Ask user: modify existing or create new?
+│  │  ├─ MODIFY → Go to "Modifying Types" workflow
+│  │  └─ CREATE → Go to "Creating Types" workflow
+│  └─ NO → Go to "Creating Types" workflow
+│
+└─ Done: convert document using the (new or existing) type
+```
+
+## Progressive Disclosure Flow
+
+The key principle: **gather information in stages, not all at once.** This prevents overwhelming users and allows the agent to make informed suggestions.
+
+### Stage 1: Understand the Document
+
+**Agent asks:**
+> "Can you share or describe the document you want to process? What kind of document is it?"
+
+**What to gather:**
+- Document type (invoice, receipt, form, report, etc.)
+- General purpose (what data needs to be extracted)
+- Sample file if available
+
+**Agent actions:**
+```bash
+# Check existing types
+docutray types list --search "<document keywords>"
+
+# If user provided a file, auto-detect
+docutray identify sample-document.pdf
+```
+
+### Stage 2: Name and Identity
+
+**Agent asks:**
+> "Let's set up the document type. What would you like to call it? I'll also need a short code (like `purchase_order`)."
+
+**What to gather:**
+- Name: Human-readable (e.g., "Acme Purchase Order")
+- Code: snake_case identifier (e.g., `acme_purchase_order`)
+- Description: One sentence
+
+**Agent suggests** a code based on the name if the user doesn't provide one.
+
+### Stage 3: Core Fields
+
+**Agent asks:**
+> "What are the 3-5 most important pieces of data you need from this document? For each, tell me what it is and what kind of value (text, number, date, etc.)."
+
+**What to gather for each field:**
+- Name (agent converts to snake_case)
+- Type (string, number, date, boolean)
+- Where it appears on the document (for the description)
+- Expected format if relevant
+
+**Agent builds** the initial schema from this information.
+
+### Stage 4: Additional Fields and Tables
+
+**Agent asks:**
+> "Are there additional fields beyond those core ones? Also, does this document have any tables or repeating sections (like line items, rows of data)?"
+
+**If tables exist:**
+- Ask for column names and types
+- Build an `array` field with `items` defining each column
+- Ask if row order matters
+
+### Stage 5: Special Formatting
+
+**Agent asks:**
+> "Does this document use any special formatting I should know about? For example: date format, number format (comma vs period for decimals), language, or multi-page layout?"
+
+**This maps to `promptHints`:**
+- Date format → `"Dates are DD/MM/YYYY"`
+- Number format → `"Comma is decimal separator"`
+- Language → `"Document is in French"`
+- Layout → `"Two-column layout"`
+
+### Stage 6: Review and Confirm
+
+**Agent presents:**
+- Complete schema as JSON
+- Proposed promptHints
+- Proposed identifyPromptHints
+- The CLI command that will be executed
+
+**Agent asks:**
+> "Here's the complete configuration. Want me to create it, or would you like to adjust anything?"
+
+### Stage 7: Create and Test
+
+**Agent executes:**
+```bash
+docutray types create --name "..." --code ... --schema schema.json \
+  --prompt-hints "..." --identify-hints "..."
+```
+
+**Then tests:**
+```bash
+docutray convert sample-document.pdf --type <code>
+```
+
+**Agent reviews** output with the user and iterates if needed.
+
+## Multi-Document Handling
+
+### Identifying Multi-Document Files
+
+Signs that a file contains multiple document types:
+- User mentions "invoice and packing slip in one PDF"
+- Different pages have clearly different layouts
+- `docutray identify` returns low confidence (confusion between types)
+
+### Strategy: Separate Types
+
+Create individual document types for each document within the file:
+
+1. **Ask the user** which pages correspond to which document type
+2. **Create separate types** with descriptive names indicating the bundle
+3. **Use promptHints** to specify page ranges or positions
+
+Example:
+```bash
+# Type for the invoice portion
+docutray types create \
+  --name "Shipping Bundle - Invoice" \
+  --code shipping_invoice \
+  --schema invoice_schema.json \
+  --prompt-hints "This is pages 1-2 of a multi-document shipping bundle."
+
+# Type for the packing slip
+docutray types create \
+  --name "Shipping Bundle - Packing Slip" \
+  --code shipping_packing_slip \
+  --schema packing_slip_schema.json \
+  --prompt-hints "This is the last page of a multi-document shipping bundle."
+```
+
+### Strategy: Repeated Same-Type Documents
+
+When one PDF contains multiple instances of the same document type (e.g., 10 invoices in one file):
+- Create a single type — DocuTray handles repeated extraction automatically
+- Use `promptHints` to indicate the repeating pattern: `"Each page is a separate invoice"`
+
+## Example Agent-User Interaction
+
+Below is an example conversation showing the progressive disclosure pattern:
+
+---
+
+**User:** I need to extract data from our purchase orders.
+
+**Agent:** Let me check if there's already a matching type.
+```bash
+docutray types list --search "purchase order"
+```
+No matching types found. Let's create one! What would you like to call this document type? I suggest "Purchase Order" with code `purchase_order`.
+
+**User:** That works. Our POs have a PO number, vendor name, order date, delivery date, and line items.
+
+**Agent:** Got it. Here's the initial schema based on those fields:
+- `po_number` (string) — the PO identifier
+- `vendor_name` (string) — vendor/supplier name
+- `order_date` (date) — when the PO was created
+- `delivery_date` (date) — expected delivery date
+- `line_items` (array) — table of ordered items
+
+For the line items, what columns does the table have?
+
+**User:** Item code, description, quantity, unit price, and total.
+
+**Agent:** Are there any additional fields I should include? And do your POs have any special formatting — like European date format or specific number formatting?
+
+**User:** Dates are DD/MM/YYYY and amounts use comma as decimal separator.
+
+**Agent:** Here's the complete schema:
+
+```json
+{
+  "type": "object",
+  "required": ["po_number", "vendor_name", "order_date", "delivery_date", "line_items"],
+  "properties": {
+    "po_number": {
+      "type": ["string", "null"],
+      "description": "Purchase order number, top of page, format: PO-XXXXX"
+    },
+    "vendor_name": {
+      "type": ["string", "null"],
+      "description": "Vendor/supplier name, in header or 'Supplier' section"
+    },
+    "order_date": {
+      "type": ["string", "null"],
+      "format": "date",
+      "description": "Order creation date"
+    },
+    "delivery_date": {
+      "type": ["string", "null"],
+      "format": "date",
+      "description": "Expected delivery date"
+    },
+    "line_items": {
+      "type": ["array", "null"],
+      "description": "Table of ordered items",
+      "items": {
+        "type": "object",
+        "required": ["item_code", "description", "quantity", "unit_price", "total"],
+        "properties": {
+          "item_code": { "type": ["string", "null"], "description": "Product/item code" },
+          "description": { "type": ["string", "null"], "description": "Item description" },
+          "quantity": { "type": ["number", "null"], "description": "Quantity ordered" },
+          "unit_price": { "type": ["number", "null"], "description": "Price per unit" },
+          "total": { "type": ["number", "null"], "description": "Line total" }
+        }
+      }
+    }
+  }
+}
+```
+
+Prompt hints: "Dates are in DD/MM/YYYY format. Amounts use comma as decimal separator (e.g., 1.234,56)."
+
+Want me to create this type, or adjust anything?
+
+**User:** Looks good, create it.
+
+**Agent:**
+```bash
+docutray types create --name "Purchase Order" --code purchase_order \
+  --description "Standard purchase order document" \
+  --schema po_schema.json \
+  --prompt-hints "Dates are in DD/MM/YYYY format. Amounts use comma as decimal separator (e.g., 1.234,56)." \
+  --identify-hints "Purchase order document, identified by 'Purchase Order' header and PO-XXXXX number."
+```
+
+Type created. Let me test it with your sample:
+```bash
+docutray convert sample-po.pdf --type purchase_order
+```

--- a/skills/docutray-advanced/references/schema-design-reference.md
+++ b/skills/docutray-advanced/references/schema-design-reference.md
@@ -207,7 +207,7 @@ For structured sub-sections (e.g., address):
   "billing_address": {
     "type": ["object", "null"],
     "description": "Billing address block, usually left side of page",
-    "required": ["street", "city", "country"],
+    "required": ["street", "city", "state", "postal_code", "country"],
     "properties": {
       "street": {
         "type": ["string", "null"],

--- a/skills/docutray-advanced/references/schema-design-reference.md
+++ b/skills/docutray-advanced/references/schema-design-reference.md
@@ -1,0 +1,354 @@
+# Schema Design — Detailed Reference
+
+## JSON Schema Structure
+
+DocuTray extraction schemas follow JSON Schema draft-07 conventions. The schema defines what fields the LLM should extract from a document.
+
+### Top-Level Structure
+
+```json
+{
+  "type": "object",
+  "required": ["field1", "field2"],
+  "properties": {
+    "field1": { ... },
+    "field2": { ... }
+  }
+}
+```
+
+## The Required + Nullable Pattern
+
+**Always prefer `required` + nullable type over optional fields.**
+
+```json
+{
+  "required": ["invoice_number", "date", "total"],
+  "properties": {
+    "invoice_number": {
+      "type": ["string", "null"],
+      "description": "Invoice ID"
+    },
+    "date": {
+      "type": ["string", "null"],
+      "format": "date",
+      "description": "Issue date"
+    },
+    "total": {
+      "type": ["number", "null"],
+      "description": "Total amount"
+    }
+  }
+}
+```
+
+**Why?** Required fields always appear in the output JSON. Using `["type", "null"]` allows the model to return `null` when a value isn't found, rather than omitting the field entirely. This makes downstream processing predictable — you always know what fields to expect.
+
+**Anti-pattern — optional fields:**
+
+```json
+{
+  "properties": {
+    "vendor": {
+      "type": "string",
+      "description": "Vendor name"
+    }
+  }
+}
+```
+
+This may omit `vendor` entirely from output, making it hard to distinguish "not found" from "not extracted."
+
+## Field Types Reference
+
+### String Fields
+
+Basic text extraction:
+
+```json
+{
+  "company_name": {
+    "type": ["string", "null"],
+    "description": "Company name from the letterhead"
+  }
+}
+```
+
+With pattern hint:
+
+```json
+{
+  "phone": {
+    "type": ["string", "null"],
+    "description": "Phone number, format: +1 (XXX) XXX-XXXX"
+  }
+}
+```
+
+### Number Fields
+
+For amounts, quantities, and measurements:
+
+```json
+{
+  "total_amount": {
+    "type": ["number", "null"],
+    "description": "Grand total including tax, as a decimal number"
+  },
+  "quantity": {
+    "type": ["integer", "null"],
+    "description": "Number of units ordered, whole number"
+  }
+}
+```
+
+Use `"type": ["number", "null"]` for decimals, `"type": ["integer", "null"]` for whole numbers.
+
+### Date Fields
+
+Dates are extracted as ISO 8601 strings:
+
+```json
+{
+  "invoice_date": {
+    "type": ["string", "null"],
+    "format": "date",
+    "description": "Invoice issue date, top-right of page"
+  },
+  "due_date": {
+    "type": ["string", "null"],
+    "format": "date",
+    "description": "Payment due date, usually 30 days after invoice date"
+  }
+}
+```
+
+The `format: "date"` tells the model to output YYYY-MM-DD regardless of how the date appears on the document. Combine with `promptHints` to specify the source format (e.g., "Dates on this document are DD/MM/YYYY").
+
+### Boolean Fields
+
+For checkbox or yes/no fields:
+
+```json
+{
+  "is_taxable": {
+    "type": ["boolean", "null"],
+    "description": "Whether tax applies, indicated by checkbox"
+  },
+  "signature_present": {
+    "type": ["boolean", "null"],
+    "description": "Whether the document has a signature"
+  }
+}
+```
+
+### Enum Fields
+
+For fields with known fixed values:
+
+```json
+{
+  "payment_method": {
+    "type": ["string", "null"],
+    "enum": ["cash", "credit_card", "bank_transfer", "check", null],
+    "description": "Payment method used"
+  },
+  "status": {
+    "type": ["string", "null"],
+    "enum": ["draft", "sent", "paid", "overdue", null],
+    "description": "Invoice status"
+  }
+}
+```
+
+**Include `null` in the enum array** when using the nullable pattern.
+
+### Array Fields (Tabular Data)
+
+For line items, rows, and repeating sections:
+
+```json
+{
+  "line_items": {
+    "type": ["array", "null"],
+    "description": "Table of purchased items, one entry per row",
+    "items": {
+      "type": "object",
+      "required": ["description", "quantity", "unit_price", "total"],
+      "properties": {
+        "description": {
+          "type": ["string", "null"],
+          "description": "Item or service description"
+        },
+        "quantity": {
+          "type": ["number", "null"],
+          "description": "Quantity ordered"
+        },
+        "unit_price": {
+          "type": ["number", "null"],
+          "description": "Price per unit"
+        },
+        "total": {
+          "type": ["number", "null"],
+          "description": "Line total (quantity × unit_price)"
+        }
+      }
+    }
+  }
+}
+```
+
+### Nested Object Fields
+
+For structured sub-sections (e.g., address):
+
+```json
+{
+  "billing_address": {
+    "type": ["object", "null"],
+    "description": "Billing address block, usually left side of page",
+    "required": ["street", "city", "country"],
+    "properties": {
+      "street": {
+        "type": ["string", "null"],
+        "description": "Street address"
+      },
+      "city": {
+        "type": ["string", "null"],
+        "description": "City name"
+      },
+      "state": {
+        "type": ["string", "null"],
+        "description": "State or province"
+      },
+      "postal_code": {
+        "type": ["string", "null"],
+        "description": "ZIP or postal code"
+      },
+      "country": {
+        "type": ["string", "null"],
+        "description": "Country name or code"
+      }
+    }
+  }
+}
+```
+
+## Writing Effective Descriptions
+
+Field descriptions are the single most impactful factor in extraction accuracy. They guide the LLM on **where** to find the value and **how** to interpret it.
+
+### Good Descriptions
+
+```json
+{
+  "invoice_number": {
+    "description": "Invoice number, top-right corner of first page, format: INV-YYYY-NNNN"
+  },
+  "total_amount": {
+    "description": "Grand total including tax, bottom-right of page, after the label 'TOTAL DUE:'"
+  },
+  "vendor_tax_id": {
+    "description": "Vendor's tax identification number, in the 'Bill From' section, format: XX-XXXXXXX"
+  }
+}
+```
+
+### Weak Descriptions (Avoid)
+
+```json
+{
+  "invoice_number": { "description": "The invoice number" },
+  "total_amount": { "description": "Total" },
+  "vendor_tax_id": { "description": "Tax ID" }
+}
+```
+
+### Description Checklist
+
+- **Location**: Where on the document is this value? (top-right, in the header, under "Bill To")
+- **Format**: What does the value look like? (INV-XXXX, $X,XXX.XX, DD/MM/YYYY)
+- **Disambiguation**: If similar values exist, how to tell them apart? ("Total before tax, NOT the grand total")
+
+## Complete Schema Example
+
+A full invoice extraction schema:
+
+```json
+{
+  "type": "object",
+  "required": [
+    "invoice_number", "date", "due_date",
+    "vendor_name", "vendor_tax_id",
+    "customer_name",
+    "subtotal", "tax_amount", "total",
+    "line_items"
+  ],
+  "properties": {
+    "invoice_number": {
+      "type": ["string", "null"],
+      "description": "Unique invoice ID, top-right, format: INV-YYYY-NNNN"
+    },
+    "date": {
+      "type": ["string", "null"],
+      "format": "date",
+      "description": "Invoice issue date, near the invoice number"
+    },
+    "due_date": {
+      "type": ["string", "null"],
+      "format": "date",
+      "description": "Payment due date, near invoice date or in payment terms"
+    },
+    "vendor_name": {
+      "type": ["string", "null"],
+      "description": "Vendor/seller company name, top-left or in 'Bill From' section"
+    },
+    "vendor_tax_id": {
+      "type": ["string", "null"],
+      "description": "Vendor tax ID, in 'Bill From' section, format: XX-XXXXXXX"
+    },
+    "customer_name": {
+      "type": ["string", "null"],
+      "description": "Customer/buyer name, in 'Bill To' or 'Ship To' section"
+    },
+    "subtotal": {
+      "type": ["number", "null"],
+      "description": "Sum before tax, labeled 'Subtotal' above the total"
+    },
+    "tax_amount": {
+      "type": ["number", "null"],
+      "description": "Tax amount, between subtotal and total"
+    },
+    "total": {
+      "type": ["number", "null"],
+      "description": "Grand total including tax, bottom-right, after 'TOTAL DUE'"
+    },
+    "line_items": {
+      "type": ["array", "null"],
+      "description": "Table of purchased items/services",
+      "items": {
+        "type": "object",
+        "required": ["description", "quantity", "unit_price", "total"],
+        "properties": {
+          "description": {
+            "type": ["string", "null"],
+            "description": "Item or service description"
+          },
+          "quantity": {
+            "type": ["number", "null"],
+            "description": "Quantity"
+          },
+          "unit_price": {
+            "type": ["number", "null"],
+            "description": "Price per unit"
+          },
+          "total": {
+            "type": ["number", "null"],
+            "description": "Line total"
+          }
+        }
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
## Related Issue
Closes #7

## OPSX Change
- **Archived to**: `openspec/changes/archive/2026-04-07-issue-7-docutray-advanced-skill/`
- **Specs synced**: document-type-workflow, schema-design, prompt-hints, docutray-advanced-skill

## Changes Summary

- **`skills/docutray-advanced/SKILL.md`** — Rewritten from placeholder to complete 329-line skill with:
  - Document type workflow (decision tree: check existing → create or modify)
  - Creating document types (6-stage progressive interaction flow)
  - Schema design guidelines (required+nullable, LLM-friendly descriptions, field types)
  - Modifying document types (retrieve → edit → update → test)
  - Prompt hints (promptHints and identifyPromptHints with examples)
  - Multi-document file handling
  - CLI command reference table

- **`references/schema-design-reference.md`** — Detailed JSON schema patterns: field types (string, number, date, enum, boolean, array, object), nullable/required combinations, effective descriptions, complete invoice schema example

- **`references/document-type-workflow-reference.md`** — Detailed decision tree, 7-stage progressive disclosure flow, multi-document strategies, full example agent-user interaction

- Removed `.gitkeep` from references directory
- Synced 4 delta specs to main specs (3 new + 1 modified)

## Completed Acceptance Criteria
- [x] SKILL.md contains complete document type creation/update workflow
- [x] Workflow starts by checking existing types (`types list`, `identify`)
- [x] Progressive disclosure pattern: name/code → fields → tabular → hints
- [x] JSON schema design guidelines with proper types and patterns
- [x] promptHints and identifyPromptHints documented with examples
- [x] CLI commands documented: `types create`, `types update`, `types list`, `types get`
- [x] Confirms with user whether to create new or modify existing
- [x] Multi-document-type files handled
- [x] References in `references/` directory, SKILL.md under 500 lines (329)
- [x] Follows docutray-platform skill pattern
- [x] Does NOT include validation rules or conversion spec

## Testing
- YAML frontmatter parses correctly (validated with Python yaml.safe_load)
- SKILL.md is 329 lines (under 500-line limit)
- All 3 cross-references use `@references/filename.md` pattern
- CLI commands match documented API from issue specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)