### PR TITLE
fix(docs): correct broken /cli links to /docs/cli (404)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Agent skills repository for [DocuTray CLI](https://docs.docutray.com/cli) — AI-powered document processing. Skills teach AI coding agents (Claude Code, Cursor, Codex, etc.) how to use `docutray-cli` commands. Published via `npx skills add docutray/docutray-skills` following the [Agent Skills specification](https://agentskills.io).
+Agent skills repository for [DocuTray CLI](https://docs.docutray.com/docs/cli) — AI-powered document processing. Skills teach AI coding agents (Claude Code, Cursor, Codex, etc.) how to use `docutray-cli` commands. Published via `npx skills add docutray/docutray-skills` following the [Agent Skills specification](https://agentskills.io).
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docutray-skills
 
-Agent skills for [DocuTray CLI](https://docs.docutray.com/cli) — AI-powered document processing from your coding agent.
+Agent skills for [DocuTray CLI](https://docs.docutray.com/docs/cli) — AI-powered document processing from your coding agent.
 
 ## Install
 
@@ -27,7 +27,7 @@ Key commands:
 - `docutray types list/get/export` — Manage extraction schemas
 - `docutray steps run/status` — Execute processing pipelines
 
-Learn more at [docutray.com](https://docutray.com) · [CLI docs](https://docs.docutray.com/cli)
+Learn more at [docutray.com](https://docutray.com) · [CLI docs](https://docs.docutray.com/docs/cli)
 
 ## Development
 

--- a/skills/docutray/references/setup/cli.md
+++ b/skills/docutray/references/setup/cli.md
@@ -152,16 +152,16 @@ A user who logged in from another terminal can be verified the same way.
 
 | Command | Help URL |
 |---|---|
-| `docutray convert` | https://docs.docutray.com/cli/convert |
-| `docutray identify` | https://docs.docutray.com/cli/identify |
-| `docutray types list` | https://docs.docutray.com/cli/types/list |
-| `docutray types get` | https://docs.docutray.com/cli/types/get |
-| `docutray types export` | https://docs.docutray.com/cli/types/export |
-| `docutray types create` | https://docs.docutray.com/cli/types/create |
-| `docutray types update` | https://docs.docutray.com/cli/types/update |
-| `docutray steps run` | https://docs.docutray.com/cli/steps/run |
-| `docutray steps status` | https://docs.docutray.com/cli/steps/status |
-| `docutray login` / `logout` / `status` | https://docs.docutray.com/cli/login |
+| `docutray convert` | https://docs.docutray.com/docs/cli/commands/convert |
+| `docutray identify` | https://docs.docutray.com/docs/cli/commands/identify |
+| `docutray types list` | https://docs.docutray.com/docs/cli/commands/types |
+| `docutray types get` | https://docs.docutray.com/docs/cli/commands/types |
+| `docutray types export` | https://docs.docutray.com/docs/cli/commands/types |
+| `docutray types create` | https://docs.docutray.com/docs/cli/commands/types |
+| `docutray types update` | https://docs.docutray.com/docs/cli/commands/types |
+| `docutray steps run` | https://docs.docutray.com/docs/cli/commands/steps |
+| `docutray steps status` | https://docs.docutray.com/docs/cli/commands/steps |
+| `docutray login` / `logout` / `status` | https://docs.docutray.com/docs/cli/commands/login |
 
 Detailed flag tables for each operation live in:
 - `references/platform/convert.md`


### PR DESCRIPTION
## Summary

`docs.docutray.com/cli` returns **404** — the docs site serves all content under `/docs`. This fixes every occurrence of the broken path across the repo, satisfying acceptance criterion #3 ("no other occurrences in the repo").

## Changes

- **`README.md`** (lines 3, 30): `…/cli` → `…/docs/cli`. This file is synced verbatim to `docs.docutray.com/docs/skills/readme`, so the broken link was published and flagged by the SEO crawl.
- **`CLAUDE.md`** (line 7): same top-level link fixed for consistency.
- **`skills/docutray/references/setup/cli.md`** (command reference table): the 10 deep-links could **not** be fixed by a bare `/docs` prefix — `…/docs/cli/convert` is also 404. Remapped each to its real page `…/docs/cli/commands/<cmd>` per the docs sitemap. `types *` and `steps *` subcommands collapse to their single `commands/types` / `commands/steps` pages; `login`/`logout`/`status` → `commands/login`.

## Tests

- `grep -rn 'docs.docutray.com/cli'` (excluding `/docs/cli`) → **no results**.
- Every `docs.docutray.com/docs/cli*` URL now in the repo verified to resolve **200** (`/docs/cli`, `commands/{convert,identify,login,steps,types}`).

Markdown-only repo — no build/lint/test gate; link resolution is the quality check.

## Scope note

Issue #11's Technical Approach anticipated only the 2 README lines, but criterion #3 is repo-wide. Investigation found the `cli.md` deep-links needed a different path structure than a simple prefix; remapped per sitemap rather than left broken.

## Downstream

After merge, re-sync in the `docutray` monorepo via `./scripts/generate-skills-docs.sh` to regenerate `content/docs/skills/readme.mdx` and bump the `vendor/docutray-skills` submodule pointer.

## Linked Issue

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)