### PR TITLE
feat: require and read an example document before generating a JSON Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,21 @@
 
 All notable changes to the `docutray` agent skill in this repository.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and from `1.1.0` onward the skill is versioned with [Semantic Versioning](https://semver.org/). The skill version is also declared in `skills/docutray/SKILL.md` frontmatter (`metadata.version`). The `2026-05-07` consolidation release is the `1.0.0` baseline.
 
 ## [Unreleased]
 
 _No changes yet._
+
+## [1.1.0] - 2026-06-09
+
+### Changed
+
+- **Custom-type design now reads an example document first.** The custom-type workflow always requests a sample document and the agent reads it with its own native file/vision tool before generating a JSON Schema, then **proposes** the fields it detected and refines with the user — instead of building the schema from a verbal field description. Phrased generically for portability across agents (Claude Code, Cursor, Codex); no-sample escape hatch warns the schema is tentative and falls back to verbal description without hard-blocking. Updates `skills/docutray/SKILL.md` §6 and `references/advanced/custom-types-workflow.md` (Stages 1 and 3, example dialog). New OpenSpec requirement *"Custom-type design reads an example document first"* synced into `openspec/specs/docutray-skill/spec.md`. ([#14](https://github.com/docutray/docutray-skills/pull/14))
+
+### Fixed
+
+- **Corrected the DocuTray docs base URL.** The docs site serves all content under `/docs`, so `docs.docutray.com/cli` returned 404. Remapped the README and `CLAUDE.md` links to `/docs/cli`, and the command-reference deep links in `references/setup/cli.md` to `/docs/cli/commands/<cmd>` (all verified 200). ([#12](https://github.com/docutray/docutray-skills/pull/12))
 
 ## 2026-05-07 — Single-skill consolidation, OAuth login, CLI 0.3.2 floor
 

--- a/openspec/changes/archive/2026-06-09-require-and-read-example-document/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-require-and-read-example-document/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/archive/2026-06-09-require-and-read-example-document/design.md
+++ b/openspec/changes/archive/2026-06-09-require-and-read-example-document/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The custom-type workflow lives in two markdown files: `skills/docutray/SKILL.md` (§6, the concise canonical path) and `skills/docutray/references/advanced/custom-types-workflow.md` (the detailed playbook with progressive-disclosure Stages 1–8 and an example dialog). Today both build the schema from the user's verbal field description; the sample document is optional and only used for `docutray identify`. This change makes reading a real sample the entry point. Markdown-only; no code or build.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make requesting + reading an example document a required precondition to schema generation.
+- Flip field-gathering to read-first: agent proposes detected fields, user refines.
+- Keep the guidance portable across coding agents and keep `SKILL.md` ≤ 500 lines.
+
+**Non-Goals:**
+- Prescribing a specific agent tool or using `docutray convert`/`identify` as the document reader.
+- Changing CLI flags, schema-design rules, or any other workflow stage beyond Stages 1/3.
+- Hard-blocking schema creation when no sample exists.
+
+## Decisions
+
+- **Reading mechanism: agent's native file/vision capability**, phrased generically ("read the document with your file/vision tool"). Rationale: Claude Code's `Read` reads PDFs/images, and the issue explicitly asks for "the tools available in the agent coder." Alternative considered — route through `docutray convert/identify` — rejected as more indirect and because the agent reads the raw document better than a pre-extracted blob for *schema design*.
+- **Mandatory with escape hatch.** Always ask for the sample; if absent, warn the schema is tentative and fall back to verbal description. Rationale: honors "siempre" without trapping users who are bootstrapping a brand-new type with no example yet.
+- **Flow inversion in Stage 3.** Replace "list your 3–5 most important fields" with "I read the document and detected these fields — confirm or adjust." Rationale: accurate, lower-friction; the agent leads with a concrete draft.
+
+## Risks / Trade-offs
+
+- [Some agents lack native PDF/vision reading] → Generic phrasing degrades gracefully; the user can paste/describe content and the escape hatch covers the no-read case.
+- [SKILL.md length creep] → Keep §6 edit to a short reordering of step 3, push detail into the reference file; re-check line count before PR.
+- [Drift between SKILL.md and the reference] → Edit both in the same change and cross-check wording.

--- a/openspec/changes/archive/2026-06-09-require-and-read-example-document/proposal.md
+++ b/openspec/changes/archive/2026-06-09-require-and-read-example-document/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+When designing a custom document type, the skill currently builds the JSON Schema from what the user *verbally describes* — field names, locations, and table structure are guesses. Reading the actual sample document first produces accurate field descriptions (where each value sits, real formats, real columns), which `schema-design.md` calls the single biggest driver of extraction quality. It also lets the agent lead with a concrete draft instead of an open-ended questionnaire. (GitHub issue #13 / Linear DOC-89, Urgent.)
+
+## What Changes
+
+- The custom-type workflow SHALL **always request an example document** before generating a JSON Schema.
+- The agent SHALL **read the document with its own native file/vision capability** to understand structure and content before drafting the schema. Phrased generically so it applies across agents (Claude Code, Cursor, Codex), without prescribing a specific tool or `docutray convert/identify` as the reader.
+- The field-gathering stage flips from *"ask the user to enumerate fields"* to **"agent proposes the fields it detected → user confirms/adjusts"** (read-first).
+- **Escape hatch:** if the user genuinely has no sample, the agent warns the schema is tentative ("validate against a real document later") and may fall back to the verbal-description flow — it does **not** hard-block.
+- The iterative refinement loop (draft → test with `docutray convert` → refine) is preserved.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `docutray-skill`: the custom-type creation guidance gains a requirement that an example document is requested and read before a JSON Schema is generated, with the read-first / propose-then-refine flow and a no-sample escape hatch.
+
+## Impact
+
+- `skills/docutray/references/advanced/custom-types-workflow.md` — Stage 1 (sample becomes required + read natively) and Stage 3 (reframed to propose-then-refine); example dialog updated.
+- `skills/docutray/SKILL.md` — §6 Custom Types, step 3 leads with reading the sample. Must stay ≤ 500 lines.
+- `openspec/specs/docutray-skill/spec.md` — new requirement (added via this change's delta on sync).
+- Markdown-only; no code, build, or runtime impact.

--- a/openspec/changes/archive/2026-06-09-require-and-read-example-document/specs/docutray-skill/spec.md
+++ b/openspec/changes/archive/2026-06-09-require-and-read-example-document/specs/docutray-skill/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Custom-type design reads an example document first
+
+When guiding a user to create a custom document type, the skill SHALL instruct the agent to request an example document and read it before generating a JSON Schema. The guidance in `skills/docutray/SKILL.md` (§6 Custom Types) and `skills/docutray/references/advanced/custom-types-workflow.md` SHALL be consistent on this behavior.
+
+The instruction SHALL be phrased generically — "read the document with your file/vision tool" — so it applies across coding agents (Claude Code, Cursor, Codex) without prescribing a specific tool name or relying on `docutray convert`/`identify` as the reader.
+
+#### Scenario: Sample requested before schema generation
+
+- **WHEN** the custom-type workflow reaches the point of building a JSON Schema
+- **THEN** the guidance SHALL direct the agent to first ask the user for an example document and read it with the agent's native file/vision capability before drafting any schema
+
+#### Scenario: Agent proposes detected fields, user refines
+
+- **WHEN** the agent has read the example document
+- **THEN** the guidance SHALL direct the agent to propose the fields and structure it detected from the document and have the user confirm or adjust them, rather than asking the user to enumerate fields from scratch
+
+#### Scenario: No-sample escape hatch
+
+- **WHEN** the user has no example document available
+- **THEN** the guidance SHALL direct the agent to warn that the resulting schema is tentative and must be validated against a real document later, and MAY fall back to building the schema from the user's verbal description — it SHALL NOT hard-block schema creation
+
+#### Scenario: Iterative refinement preserved
+
+- **WHEN** an initial schema has been drafted from the example document
+- **THEN** the guidance SHALL retain the iterative loop of testing with `docutray convert <sample> -t <code>` and refining the schema with the user

--- a/openspec/changes/archive/2026-06-09-require-and-read-example-document/tasks.md
+++ b/openspec/changes/archive/2026-06-09-require-and-read-example-document/tasks.md
@@ -1,0 +1,17 @@
+## 1. Update the detailed playbook (custom-types-workflow.md)
+
+- [x] 1.1 Stage 1: make the example document **required** (not "if available"); instruct the agent to read it with its native file/vision tool to understand structure and content before any schema work.
+- [x] 1.2 Stage 3: reframe from "ask the user to enumerate 3–5 fields" to "agent proposes the fields/structure it detected from the document → user confirms/adjusts".
+- [x] 1.3 Add the no-sample escape hatch: warn the schema is tentative and validate later; allow fallback to verbal description without hard-blocking.
+- [x] 1.4 Update the example agent–user dialog to show read-first → propose → refine.
+
+## 2. Update the canonical path (SKILL.md §6)
+
+- [x] 2.1 Rewrite step 3 ("Gather progressively") to lead with requesting + reading the sample, then propose-then-refine.
+- [x] 2.2 Keep the escape-hatch note brief; defer detail to the reference file.
+
+## 3. Consistency & validation
+
+- [x] 3.1 Cross-check wording between SKILL.md §6 and custom-types-workflow.md.
+- [x] 3.2 Confirm SKILL.md stays ≤ 500 lines.
+- [x] 3.3 Run `openspec validate require-and-read-example-document --strict`.

--- a/openspec/specs/docutray-skill/spec.md
+++ b/openspec/specs/docutray-skill/spec.md
@@ -110,6 +110,28 @@ Documentation of the `docutray convert` response SHALL describe the body as `{ "
 - **WHEN** a convert response example is shown
 - **THEN** the surrounding text SHALL note that the keys inside `data` come from the active document type's schema and that example values are illustrative
 
+### Requirement: Custom-type design reads an example document first
+
+When guiding a user to create a custom document type, the skill SHALL instruct the agent to request an example document and read it before generating a JSON Schema. The guidance in `skills/docutray/SKILL.md` (§6 Custom Types) and `skills/docutray/references/advanced/custom-types-workflow.md` SHALL be consistent on this behavior.
+
+The instruction SHALL be phrased generically — "read the document with your file/vision tool" — so it applies across coding agents (Claude Code, Cursor, Codex) without prescribing a specific tool name or relying on `docutray convert`/`identify` as the reader.
+
+#### Scenario: Sample requested before schema generation
+- **WHEN** the custom-type workflow reaches the point of building a JSON Schema
+- **THEN** the guidance SHALL direct the agent to first ask the user for an example document and read it with the agent's native file/vision capability before drafting any schema
+
+#### Scenario: Agent proposes detected fields, user refines
+- **WHEN** the agent has read the example document
+- **THEN** the guidance SHALL direct the agent to propose the fields and structure it detected from the document and have the user confirm or adjust them, rather than asking the user to enumerate fields from scratch
+
+#### Scenario: No-sample escape hatch
+- **WHEN** the user has no example document available
+- **THEN** the guidance SHALL direct the agent to warn that the resulting schema is tentative and must be validated against a real document later, and MAY fall back to building the schema from the user's verbal description — it SHALL NOT hard-block schema creation
+
+#### Scenario: Iterative refinement preserved
+- **WHEN** an initial schema has been drafted from the example document
+- **THEN** the guidance SHALL retain the iterative loop of testing with `docutray convert <sample> -t <code>` and refining the schema with the user
+
 ### Requirement: Drift sweep grep is clean
 The repository SHALL contain none of the broken patterns enumerated in the corrections table at the time `consolidate-into-single-skill` is archived.
 

--- a/skills/docutray/SKILL.md
+++ b/skills/docutray/SKILL.md
@@ -10,6 +10,8 @@ description: >-
   --base-url for staging), and troubleshooting. Use this skill whenever a
   task involves docutray, document conversion, document-type identification,
   or extraction schemas.
+metadata:
+  version: "1.1.0"
 ---
 
 # DocuTray

--- a/skills/docutray/SKILL.md
+++ b/skills/docutray/SKILL.md
@@ -254,9 +254,10 @@ When no existing type fits, design a new document type. The high-level flow:
 
 1. **Check first.** Run `docutray types list --search <term>` and `docutray identify <file>` before creating anything.
 2. **Decide.** High-confidence existing match → use it. Partial match → ask the user (modify or create new). No match → create new.
-3. **Gather progressively.** Don't dump every question at once: name/code → main fields → additional fields & tabular data → prompt hints → review → execute.
-4. **Create or update.** Use `docutray types create` (full flag set) or `docutray types update <code>`. Both accept `--schema` (file path or inline JSON), `--name`, `--description`, `--prompt-hints`, `--identify-hints`, `--conversion-mode {json|toon|multi_prompt}`, `--keep-ordering`, `--publish`/`--draft`. `create` additionally requires `--code`.
-5. **Test.** Run `docutray convert <sample> -t <code>` and iterate.
+3. **Get and read an example first.** Always ask for an example document and read it with your own file/vision tool (Read/vision — most agents open PDFs and images directly) before generating a schema. Then **propose** the fields you detected and let the user adjust — don't make them enumerate fields blind. No sample? Warn the schema is tentative (validate against a real document later) and fall back to gathering fields by description; don't block.
+4. **Gather the rest progressively.** Don't dump every question at once: name/code → confirm detected fields → additional fields & tabular data → prompt hints → review → execute.
+5. **Create or update.** Use `docutray types create` (full flag set) or `docutray types update <code>`. Both accept `--schema` (file path or inline JSON), `--name`, `--description`, `--prompt-hints`, `--identify-hints`, `--conversion-mode {json|toon|multi_prompt}`, `--keep-ordering`, `--publish`/`--draft`. `create` additionally requires `--code`.
+6. **Test.** Run `docutray convert <sample> -t <code>` and iterate.
 
 ```bash
 docutray types create \

--- a/skills/docutray/references/advanced/custom-types-workflow.md
+++ b/skills/docutray/references/advanced/custom-types-workflow.md
@@ -27,21 +27,27 @@ User wants to extract data from a document
 
 The principle: **gather information in stages, not all at once.** It prevents overwhelming users and lets the agent make informed suggestions.
 
-### Stage 1: Understand the document
+### Stage 1: Get and read an example document
+
+**Always ask for an example document before designing a schema.** The agent reads the actual file to discover the real fields, their positions, and their formats — that produces far better extraction descriptions than a verbal description ever could.
 
 **Agent asks:**
-> "Can you share or describe the document you want to process? What kind of document is it?"
-
-**Gather:**
-- Document type (invoice, receipt, form, report, …)
-- General purpose (what data needs extracting)
-- Sample file if available
+> "Can you share an example of this document? I'll read it to understand its structure before we design the schema."
 
 **Agent actions:**
-```bash
-docutray types list --search "<document keywords>"
-docutray identify sample-document.pdf  # if sample provided
-```
+1. **Read the document with your own file/vision tool.** Most coding agents (Claude Code, Cursor, Codex) can open PDFs and images directly — use that native capability to inspect the sample's layout, fields, and any tables. Do **not** rely on `docutray convert`/`identify` to "see" the document for schema design; read it yourself.
+2. Check for an existing matching type while you're at it:
+   ```bash
+   docutray types list --search "<document keywords>"
+   docutray identify sample-document.pdf --types <candidate-codes>
+   ```
+
+**Gather (from reading + a short confirmation):**
+- Document type (invoice, receipt, form, report, …)
+- General purpose (what data needs extracting)
+- The actual fields, locations, formats, and tables visible in the sample
+
+**No sample available?** Warn the user that the schema will be **tentative** and must be validated against a real document later, then fall back to gathering fields by description (Stages 3–4 as a verbal Q&A). Do not block — just flag the schema as unverified until a real document is run through it.
 
 ### Stage 2: Name and identity
 
@@ -57,16 +63,20 @@ The code must be unique and lowercase; the agent suggests one based on the name 
 
 ### Stage 3: Core fields
 
-**Agent asks:**
-> "What are the 3–5 most important pieces of data you need from this document? For each, tell me what it is and what kind of value (text, number, date, etc.)."
+Lead with what you read, don't interrogate. Having read the document in Stage 1, the agent **proposes** the fields it detected and asks the user to confirm or adjust — rather than asking the user to enumerate fields from scratch.
 
-**Gather per field:**
-- Name (agent normalizes to `snake_case`)
+**Agent says:**
+> "From the document I read these core fields: `invoice_number` (top-right), `issue_date` (under the number), `total` (bottom-right). Did I miss anything, and are these the ones you need?"
+
+**For each detected field, infer and record:**
+- Name (normalized to `snake_case`)
 - Type (`string`, `number`, `date`, `boolean`)
 - Where it appears on the page (for the JSON Schema `description`)
-- Expected format if relevant
+- Expected format if visible
 
-The agent builds the initial JSON Schema from this information using the **required + nullable** pattern (see `schema-design.md`).
+The user confirms, removes, or adds fields. The agent builds the initial JSON Schema from the agreed list using the **required + nullable** pattern (see `schema-design.md`).
+
+(If no sample was available, fall back to asking: "What are the 3–5 most important pieces of data you need, and what kind of value is each?" — and mark the schema tentative per Stage 1.)
 
 ### Stage 4: Additional fields and tabular data
 
@@ -267,21 +277,17 @@ A condensed walkthrough showing the progressive flow.
 
 **User:** I need to extract data from our purchase orders.
 
-**Agent:** Let me check if there's already a matching type.
+**Agent:** Can you share an example PO? I'll read it before we design the schema.
+
+**User:** Here's `sample-po.pdf`.
+
+**Agent:** *(reads the PDF with its file/vision tool, and checks for an existing type)*
 ```bash
 docutray types list --search "purchase order"
 ```
-No matching types. Let's create one. I suggest **"Purchase Order"** with code `purchase-order`. Sound good?
+No matching types. From the document I see: PO number (top-right, `PO-XXXXX`), vendor name (header), order date and delivery date (under the header), and a line-items table with columns Item code, Description, Quantity, Unit price, Total. I suggest a type **"Purchase Order"** with code `purchase-order` covering those fields. Did I miss anything?
 
-**User:** Yes.
-
-**Agent:** What are the most important fields you need?
-
-**User:** PO number, vendor name, order date, delivery date, and line items.
-
-**Agent:** Got it. For the line items table, what columns does it have?
-
-**User:** Item code, description, quantity, unit price, total.
+**User:** That's all of them.
 
 **Agent:** Any special formatting — date format, decimal separators, language, layout?
 


### PR DESCRIPTION
## Summary

Makes the custom-type workflow **always request an example document and read it before generating a JSON Schema**, instead of building the schema from the user's verbal field description. The agent reads the sample with its own native file/vision tool, proposes the fields it detected, and iterates with the user from there.

Implements GitHub issue #13 / Linear DOC-89 (Urgent).

## Changes

- **`skills/docutray/SKILL.md` §6** — step 3 now leads with requesting + reading the sample, then propose-then-refine; brief no-sample escape-hatch note. Renumbered following steps. Still 349 lines (≤ 500).
- **`skills/docutray/references/advanced/custom-types-workflow.md`**
  - Stage 1: example document is **required** and read with the agent's native file/vision tool (not via `docutray convert/identify`); added the no-sample escape hatch (tentative schema, no hard-block).
  - Stage 3: reframed from "ask the user to enumerate fields" to "agent proposes detected fields → user confirms/adjusts".
  - Example dialog updated to show read-first → propose → refine.
- **OpenSpec** — new requirement *"Custom-type design reads an example document first"* (4 scenarios) synced into `openspec/specs/docutray-skill/spec.md`; change archived at `openspec/changes/archive/2026-06-09-require-and-read-example-document/`.

### Design decisions
- **Reading mechanism:** agent's native capability, phrased generically for portability (Claude Code, Cursor, Codex).
- **Mandatory with escape:** always ask; if no sample, warn + fall back, never block.
- **Flow inversion:** read → propose → refine.

## Tests

Markdown-only repo — no automated tests. Verified: `openspec validate --all --strict` passes; drift-sweep grep clean; SKILL.md within the 500-line cap; SKILL.md and the reference file are consistent.

## Linked Issue

Closes #13

## Versioning

This PR also bumps the skill to **`1.1.0`** (SemVer; the `2026-05-07` consolidation is the `1.0.0` baseline):
- Declares `metadata.version: "1.1.0"` in `skills/docutray/SKILL.md` frontmatter, per the Agent Skills spec.
- Adds a `## [1.1.0] - 2026-06-09` section to `CHANGELOG.md` grouping the unreleased changes — this read-example-document workflow change (**Changed**) and the earlier docs URL fix #12 (**Fixed**) — and resets `[Unreleased]`.
- A `v1.1.0` git tag should be created at merge time.